### PR TITLE
Set the actual opsworks region as default

### DIFF
--- a/check_opsworks
+++ b/check_opsworks
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export LC_CTYPE="C"
-export AWS_DEFAULT_REGION="eu-west-1"
+export AWS_DEFAULT_REGION="us-east-1"
 export AWS_ACCESS_KEY_ID=$1
 export AWS_SECRET_ACCESS_KEY=$2
 


### PR DESCRIPTION
according to http://docs.aws.amazon.com/opsworks/latest/userguide/cli-examples.html, OpsWorks has only one endpoint, us-east-1
